### PR TITLE
Fix the ambiguous "execute" button and button placement

### DIFF
--- a/data/texts
+++ b/data/texts
@@ -581,6 +581,10 @@ sv_SV.UTF-8	Hjälp:
 tr_TR.UTF-8	Yardım:
 uk_UA.UTF-8	Допомога:
 
+text		Transfer the program to the ant
+en_US.UTF-8	Transfer the program to the ant
+fr_FR.UTF-8	Mettre le programme dans la fourmi
+
 text		graphic interface configuration
 cs_CZ.UTF-8	nastavení rozhraní
 da_DK.UTF-8	kongiguration af grafisk brugerflade

--- a/src/gfx.ml
+++ b/src/gfx.ml
@@ -185,6 +185,8 @@ let label_prog = F.x "Program:" []
 let label_mesg = F.x "Messages:" []
 let label_help = F.x "Help:" []
 
+let label_execute = F.x "Transfer the program to the ant" []
+
 let layout () =
   let scrolled ?(vpolicy=`ALWAYS) packing =
     GBin.scrolled_window ~packing ~hpolicy:`AUTOMATIC ~vpolicy ()
@@ -220,11 +222,6 @@ let layout () =
   view_prog#set_indent 1;
   view_prog#misc#modify_font monofont;
   let rbvbox = GPack.vbox ~packing:vpaned#add2 () in
-  label_txt (Fd.render_raw label_mesg) rbvbox#pack;
-  let sw_mesg = scrolled rbvbox#add in
-  let view_mesg = GText.view ~editable:false ~packing:sw_mesg#add  () in
-  view_mesg#misc#modify_font monofont;
-  let px = GMisc.image ~packing:sw_laby#add_with_viewport () in
   let toolbar = GButton.toolbar ~packing:rbvbox#pack ~style:`BOTH () in
   let button stock = GButton.tool_button ~packing:toolbar#insert ~stock () in
   let tbutton stock =
@@ -238,8 +235,14 @@ let layout () =
   let button_play = tbutton `MEDIA_PLAY in
   let button_forward = tbutton `MEDIA_FORWARD in
   view_prog#misc#grab_focus ();
-  let bbox = GPack.hbox ~packing:rtvbox#pack () in
-  let button_execute = GButton.button ~packing:bbox#pack ~stock:`EXECUTE () in
+  label_txt (Fd.render_raw label_mesg) rbvbox#pack;
+  let sw_mesg = scrolled rbvbox#add in
+  let view_mesg = GText.view ~editable:false ~packing:sw_mesg#add  () in
+  view_mesg#misc#modify_font monofont;
+  let px = GMisc.image ~packing:sw_laby#add_with_viewport () in
+  let bbox = GPack.hbox ~packing:rtvbox#pack ~homogeneous:true () in
+  let button_execute = GButton.button ~packing:bbox#pack ~relief:`NORMAL
+    ~label:(Fd.render_raw label_execute) () in
   button_execute#set_focus_on_click false;
   {
     window = window;


### PR DESCRIPTION
I changed the execute button since it does not execute anything to a more precise button. This patch also changes a bit the disposition of the buttons to make it more readable.
