### PR TITLE
src/gfx.ml: Fix height of help sourceview.

### DIFF
--- a/src/gfx.ml
+++ b/src/gfx.ml
@@ -260,7 +260,7 @@ let layout () =
   label_txt (Fd.render_raw label_help) box_help#pack;
   let sw_help = scrolled box_help#pack in
   let view_help =
-    GSourceView2.source_view ~editable:false ~packing:sw_help#add ()
+    GSourceView2.source_view ~height:100 ~editable:false ~packing:sw_help#add ()
   in
   view_help#set_indent 1;
   view_help#misc#modify_font monofont;


### PR DESCRIPTION
Help view was not displayed on Ubuntu (and I guess any recent version of lablgtksourceview). This patch fixes that.