### PR TITLE
python3 language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# laby
+Learn programming, playing with ants and spider webs ;-)
+
+Provide Python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-# laby
-Learn programming, playing with ants and spider webs ;-)
-
-Provide Python3

--- a/data/mods/python3/help
+++ b/data/mods/python3/help
@@ -1,0 +1,23 @@
+basic:
+laby_name_forward()
+laby_name_left()
+laby_name_right()
+laby_name_escape()
+
+rocks:
+laby_name_take()
+laby_name_drop()
+
+loop:
+while laby_name_look() == laby_name_"void":
+  ...
+
+function:
+def f():
+  ...
+
+conditional:
+if laby_name_look() == laby_name_"web":
+  ...
+else:
+  ...

--- a/data/mods/python3/lib/robot.py
+++ b/data/mods/python3/lib/robot.py
@@ -1,0 +1,39 @@
+def look():
+    "Expected responses from look(): void, wall, rock, web, exit."
+    response = input("look\n")
+    say(response)
+    if response == "quit":
+        exit(0)
+    return response
+
+
+def left():
+    return input("left\n")
+
+
+def right():
+    return input("right\n")
+
+
+def forward():
+    return input("forward\n")
+
+
+def take():
+    return input("take\n")
+
+
+def drop():
+    return input("drop\n")
+
+
+def escape():
+    return input("escape\n")
+
+
+def say(s):
+    "Prompt string is returned and displays in the Messages panel."
+    input("say " + s + "\n")
+
+
+input("start\n")

--- a/data/mods/python3/rules
+++ b/data/mods/python3/rules
@@ -1,0 +1,7 @@
+info:
+need	python3
+
+run:
+fetch	robot.py
+dump	program.py
+spawn	python3 program.py

--- a/data/mods/python3/skel
+++ b/data/mods/python3/skel
@@ -1,0 +1,15 @@
+from robot import *
+
+laby_name_right()
+laby_name_forward()
+laby_name_take()
+laby_name_left()
+laby_name_forward()
+laby_name_drop()
+laby_name_right()
+laby_name_forward()
+laby_name_left()
+laby_name_forward()
+laby_name_forward()
+laby_name_right()
+laby_name_escape()


### PR DESCRIPTION
# Support for the Python 3 Language 

Laby currently supports programming of the ant in the Python language version 2. 

Python 2 was released 20 years ago and was officially discontinued at the beginning this year. Python 3, version 3.5 and later, are the currently supported releases. Some Linux distributions are now no longer including Python 2 as part of the distribution.

This pull request is for providing Python 3 as a language for Laby. Four new files are added:
```
/usr/share/laby/mods/python3/
├── help
├── lib
│   └── robot.py
├── rules
└── skel
```
To highlight some of the changes between the Python 2 and Python 3 *robot.py* files:

- The file is now [PEP8]( https://www.python.org/dev/peps/pep-0008/ ) compliant.
- The local `output()` and `input()` functions have been removed.
- The `import sys;` is removed.
- `sys.stdout.write()`  and `sys.stdout.flush()` are replaced by the *prompt* feature of Python3 builtin *input()* function.
- The `sys.stdin.readline()` is replaced by the Python 3 builtin *input()* function.
- When using `look()` the string received by *input()* is returned without adding the complexity of enumerated constants.

The *help*, *rules*, and *skel* files have had minor modifications from their Python 2 versions to make them suitable for use with Python 3. 

Upon implementing support in Laby for the Python 3 language, the Python 2 functionality should be deprecated.

Regards, Ian Stewart. 2020-05-21
