### PR TITLE
Use TMPDIR from runtime

### DIFF
--- a/build
+++ b/build
@@ -7,7 +7,6 @@ source build.conf || exit 1
 
 export PREFIX=${PREFIX-/usr}
 export DATADIR=${DATADIR-${PREFIX}/share}
-export TMPDIR=${TMPDIR-/tmp}
 
 export PROJECT_NAME=${PROJECT_NAME-unknown}
 export PROJECT_VERSION=${PROJECT_VERSION-unknown}

--- a/src/config.sh
+++ b/src/config.sh
@@ -29,5 +29,4 @@ let build_ocaml = "${OCAML_VERSION}"
 let build_lablgtk = "${BUILD_LABLGTK}"
 let build_lablgtk_sourceview = "${BUILD_LABLGTKSV}"
 let _ = Res.sys_data_dir := "${DATADIR}"
-let _ = Res.sys_tmp_dir := "${TMPDIR}"
 EOF

--- a/src/laby.ml
+++ b/src/laby.ml
@@ -48,6 +48,7 @@ let opts =
 
 let _ =
   Printexc.record_backtrace true;
+  Res.sys_tmp_dir := Filename.get_temp_dir_name ();
   Run.init
     ~name:Config.project_name
     ~conf:(conf, ["conf"])


### PR DESCRIPTION
Hi, 

laby is not working properly, because the value of TMPDIR is hard-coded and the one that was compiled in is not the correct one at runtime in guix.

Can you please take a look at the pull request? 

Thanks in advance :)

Best regards